### PR TITLE
fix HTTP 404-link for show notes

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -28,7 +28,7 @@
             Hello! This is a podcast about learning the programming language
             Rust—from scratch! Apart from this spiffy landing page, all the site
             content is built with Rust's own documentation tools. You can hear
-            more about why I'm doing this in <a href="/show_notes/e00/">00: Why
+            more about why I'm doing this in <a href="/show_notes/e000/">000: Why
             Am I Here?</a>. And there's much more to come!
           </p>
         </div>


### PR DESCRIPTION
A missing `0` in the `href` introduced a 404.
