### PR TITLE
Fix character pattern match demonstration

### DIFF
--- a/src/e003.rs
+++ b/src/e003.rs
@@ -205,7 +205,7 @@ pub fn demonstrate_match() {
     println!("I asked: '{:}'; the answer was: {:}", question, answer);
 
     // or letters...
-    let character = 'c';
+    let character = 'C';
     match character {
         'A'...'B' => println!("Nope, not those letters."),
         'C' => println!("Why, yes, my name *does* start with a 'C'"),


### PR DESCRIPTION
Hi (and thanks for this great podcast!),

Due to the (lower) case of the character variable binding, the pattern match against character example was matching the "'D'...'z'" arm, when the intention seems to be the "'C'" arm (according to messages printed to the standard output).

Another fix could have been to change the messages so that the "'D'...'z'" arm becomes the expected one; I chose the simplest fix as I assumed you did not want to start explaining ranges of characters here in addition to pattern matching.

Cheers!
