### PR TITLE
C++14 update for Episode 15 documentation

### DIFF
--- a/src/e015.rs
+++ b/src/e015.rs
@@ -143,17 +143,14 @@
 //!
 //! It's also worth comparing the Rust code above with similar code in C++.
 //! Assume we have a `class` with the same name; using a smart pointer (in this
-//! case, `unique_ptr`) would give us this code:
+//! case, `unique_ptr`, returned from `make_unique`) would give us this code:
 //!
 //! ```cpp
-//! unique_ptr<Foo> someFoo(new Foo("bar"));
+//! const auto someFoo = std::make_unique<const Foo>("bar");
 //! ```
 //!
-//! You can see that these are similar in length (the declaration is actually
-//! the same number of characters). You're gaining *at least* some better
-//! guarantees in Rust; I'd argue you're also making a substantial gain in the
-//! clarity of the code (in that reading left to right as is normal in English,
-//! it's much clearer how the pieces fit together without backtracking).
+//! Both examples declare a smart pointer named `someFoo` that points to an
+//! immutable/constant `Foo` and where the pointer itself is immutable/constant.
 //!
 //! I'm not including further comments on `Box` here in the docs, because we've
 //! covered it before and it's fairly straightforward. The rest of these


### PR DESCRIPTION
This refreshes the C++ code snippet to use the latest C++14 idiom for declaring
a `unique_ptr`—i.e., to use `make_unique` instead of calling the `unique_ptr`
constructor directly.

Also, the new code snippet adds missing `const` modifiers to make the C++
example match the Rust example regarding constness/immutability.

The code change makes some of the related commentary obsolete, so I deleted the
commentary. I expect chriskrycho will add back whatever new, revised commentary
he has to offer.
