### PR TITLE
Fix missing latest episode link in feed.xml

### DIFF
--- a/resources/feed.xml
+++ b/resources/feed.xml
@@ -42,6 +42,7 @@
         <itunes:type>episodic</itunes:type>
         <item>
             <title>Increasing Rust's Reach: Lee Baillie</title>
+            <link>http://www.newrustacean.com/show_notes/interview/irr_2017/lee_baillie/</link>
             <description><![CDATA[<p>Lee’s experience designing a new website for Rust.</p>
 <h2 id="show-notes">Show Notes</h2>
 <ul>


### PR DESCRIPTION
There's no link  to the latest episode in `resources/feed.xml`, so can't open the article from RSS reader.