### PR TITLE
Point to current Amethyst examples

### DIFF
--- a/docs/news/rust-1-32.md
+++ b/docs/news/rust-1-32.md
@@ -66,7 +66,7 @@ The first of those is [Amethyst]: a game engine [written in Rust]. As an aside, 
 [written in Rust]: https://github.com/amethyst/amethyst
 [keynote]: https://m.youtube.com/watch?v=aKLntZcp27M
 [a whole book]: https://www.amethyst.rs/book/latest/
-[examples]: https://github.com/amethyst/amethyst/tree/v0.9.0/examples
+[examples]: https://github.com/amethyst/amethyst/tree/v0.10.0/examples
 [docs]: https://www.amethyst.rs/book/latest/
 
 ### [`insta`][insta]

--- a/resources/feed.xml
+++ b/resources/feed.xml
@@ -54,7 +54,7 @@
 </ul></li>
 <li><a href="https://www.amethyst.rs/">Amethyst</a>
 <ul>
-<li><a href="https://github.com/amethyst/amethyst/tree/v0.9.0/examples">examples</a></li>
+<li><a href="https://github.com/amethyst/amethyst/tree/v0.10.0/examples">examples</a></li>
 <li><a href="https://www.amethyst.rs/book/latest/">docs</a></li>
 <li><a href="https://m.youtube.com/watch?v=aKLntZcp27M">RustConf 2018 keynote</a></li>
 </ul></li>

--- a/src/news/rust_1_32.rs
+++ b/src/news/rust_1_32.rs
@@ -28,7 +28,7 @@
 //! [release notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1320-2019-01-17
 //! [Twitter]: https://twitter.com/softprops/status/1086723200095059972
 //! [Amethyst]: https://www.amethyst.rs/
-//! [examples]: https://github.com/amethyst/amethyst/tree/v0.9.0/examples
+//! [examples]: https://github.com/amethyst/amethyst/tree/v0.10.0/examples
 //! [docs]: https://www.amethyst.rs/book/latest/
 //! [RustConf 2018 keynote]: https://m.youtube.com/watch?v=aKLntZcp27M
 //! [insta]: https://crates.io/crates/insta


### PR DESCRIPTION
### Fixed

* Update all links to Amethyst examples to point to v0.10.0 (the current version) instead of v0.9.0.

Please let me know whether you would like to cherry-pick any of the commits, in particular the `feed.xml`, as I don't know if it's automatically generated. Thanks for the fun and informative episode, Chris. Keep it up! :smile: 