### PR TITLE
Fix function body for distance_between in e025

### DIFF
--- a/docs/e025-script.md
+++ b/docs/e025-script.md
@@ -94,7 +94,7 @@ Now, what if we find this “get the distance between two points” function use
 
 ```rust,ignore
 fn distance_between(a: &Point, b: &Point) -> f32 {
-    let change = point - origin;
+    let change = a - b;
     (change.x.powi(2) + change.y.powi(2)).sqrt();
 }
 ```


### PR DESCRIPTION
Either the signature should be changed to use `point` and `origin` or
the body to use `a` and `b` I guess. Since you said "a and b" in the
audio version, I opted for that in the fn body as well.

Thanks for the podcast! I haven't written almost anything in Rust yet(been travelling for the last month), but have listened and watched a lot of material and can't wait to get my hands dirty.