### PR TITLE
Allow building on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 cache: cargo
 rust:
 - nightly
+- stable
 branches:
   only:
   - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Chris Krycho <chris@chriskrycho.com>"]
 [dependencies]
 regex = "0.2"
 libc = "0.2.54"
+select-rustc = "0.1.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/bonus/_10.rs
+++ b/src/bonus/_10.rs
@@ -156,5 +156,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/bonus/10-script.md")]
 pub struct Script;

--- a/src/bonus/_13.rs
+++ b/src/bonus/_13.rs
@@ -251,5 +251,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/bonus/13-silly-mistakes.md")]
 pub struct Script;

--- a/src/bonus/_14.rs
+++ b/src/bonus/_14.rs
@@ -266,5 +266,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/bonus/14-my-workflow.md")]
 pub struct Script;

--- a/src/bonus/burnout.rs
+++ b/src/bonus/burnout.rs
@@ -187,5 +187,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/bonus/burnout-script.md")]
 pub struct Script;

--- a/src/bonus/translating_between_languages.rs
+++ b/src/bonus/translating_between_languages.rs
@@ -193,5 +193,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/bonus/translating-between-languages-script.md")]
 pub struct Script;

--- a/src/cysk/serde.rs
+++ b/src/cysk/serde.rs
@@ -154,5 +154,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/cysk/serde.md")]
 pub struct Script;

--- a/src/cysk/wasm.rs
+++ b/src/cysk/wasm.rs
@@ -159,5 +159,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/cysk/serde.md")]
 pub struct Script;

--- a/src/e007.rs
+++ b/src/e007.rs
@@ -121,9 +121,11 @@ mod tests {
     // access to the functions we want to test.
     use super::*;
 
+    #[rustc::nightly]
     // `Bencher` is the `struct` which has the benchmarking functionality.
     use crate::test::Bencher;
 
+    #[rustc::nightly]
     // We'll use this for demonstrating benchmarks later.
     use std::thread::sleep;
     use std::time::Duration;
@@ -153,6 +155,7 @@ mod tests {
         panic!("Crazed monkeys!");
     }
 
+    #[rustc::nightly]
     /// Benchmark our addition function.
     ///
     /// Note: it's trivial, so it's probably pretty quick (`0 ns/iter (+/- 0)`).
@@ -173,6 +176,7 @@ mod tests {
         Duration::new(0, ns)
     }
 
+    #[rustc::nightly]
     /// Benchmark a function that sleeps for 1ms every time you call it.
     ///
     /// One of the things this highlights: we have a *tiny* duration (10 ns)...

--- a/src/e014.rs
+++ b/src/e014.rs
@@ -166,6 +166,7 @@ pub mod demo_deref {
     impl Deref for Origin {
         type Target = DerefTarget;
 
+        #[allow(unconditional_recursion)]
         #[cfg_attr(feature = "clippy", allow(unconditional_recursion))]
         fn deref(&self) -> &DerefTarget {
             self

--- a/src/e022.rs
+++ b/src/e022.rs
@@ -145,6 +145,7 @@
 
 use std::thread;
 
+#[rustc::nightly]
 #[doc(include = "../docs/e022-script.md")]
 pub struct Script;
 

--- a/src/e023.rs
+++ b/src/e023.rs
@@ -180,6 +180,7 @@
 
 use regex::Regex;
 
+#[rustc::nightly]
 #[doc(include = "../docs/e023-script.md")]
 pub struct Script;
 

--- a/src/e024.rs
+++ b/src/e024.rs
@@ -175,6 +175,7 @@
 use std::fmt::Display;
 use std::ops::Add;
 
+#[rustc::nightly]
 #[doc(include = "../docs/e024-script.md")]
 pub struct Script;
 

--- a/src/e025.rs
+++ b/src/e025.rs
@@ -259,5 +259,6 @@ pub fn distance_from_impl<'a, 'b: 'a>(offset: &'b Point) -> impl FnMut(&'a Point
     }
 }
 
+#[rustc::nightly]
 #[doc(include = "../docs/e025-script.md")]
 pub struct Script;

--- a/src/e026.rs
+++ b/src/e026.rs
@@ -192,5 +192,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/e026-script.md")]
 pub struct Script;

--- a/src/e027.rs
+++ b/src/e027.rs
@@ -276,5 +276,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/e027-script.md")]
 pub struct Script;

--- a/src/e028.rs
+++ b/src/e028.rs
@@ -260,5 +260,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/e028-script.md")]
 pub struct Script;

--- a/src/e029/mod.rs
+++ b/src/e029/mod.rs
@@ -276,6 +276,7 @@
 
 use std::os::raw::c_float;
 
+#[rustc::nightly]
 #[doc(include = "../docs/e029-script.md")]
 pub struct Script;
 

--- a/src/e030.rs
+++ b/src/e030.rs
@@ -275,6 +275,7 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/e030-script.md")]
 pub struct Script;
 

--- a/src/e031/mod.rs
+++ b/src/e031/mod.rs
@@ -291,6 +291,7 @@ use std::fmt::{Display, Error, Formatter};
 
 use libc::{c_char, c_float, c_int};
 
+#[rustc::nightly]
 #[doc(include = "../docs/e031-script.md")]
 pub struct Script;
 

--- a/src/interview/rbr_2017/anthony_deschamps.rs
+++ b/src/interview/rbr_2017/anthony_deschamps.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/anthony_deschamps.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/anthony-deschamps.md")]
 pub struct Transcript;

--- a/src/interview/rbr_2017/arun_kulshreshthra.rs
+++ b/src/interview/rbr_2017/arun_kulshreshthra.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/arun_kulshreshthra.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/arun-kulshreshtha.md")]
 pub struct Transcript;

--- a/src/interview/rbr_2017/ben_striegel.rs
+++ b/src/interview/rbr_2017/ben_striegel.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/ben_striegel.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/ben-striegel.md")]
 pub struct Transcript;

--- a/src/interview/rbr_2017/colin_dean.rs
+++ b/src/interview/rbr_2017/colin_dean.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/colin_dean.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/colin-dean.md")]
 pub struct Transcript;

--- a/src/interview/rbr_2017/holden_marcsisin.rs
+++ b/src/interview/rbr_2017/holden_marcsisin.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/holden_marcsisin.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/holden-marcsisin.md")]
 pub struct Transcript;

--- a/src/interview/rbr_2017/jess_saxeter.rs
+++ b/src/interview/rbr_2017/jess_saxeter.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/jess_saxeter.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/jess-saxeter.md")]
 pub struct Transcript;

--- a/src/interview/rbr_2017/pete_lyons.rs
+++ b/src/interview/rbr_2017/pete_lyons.rs
@@ -9,5 +9,6 @@
 //!   <source src="https://www.podtrac.com/pts/redirect.mp3/f001.backblazeb2.com/file/newrustacean/interview/rbr/pete_lyons.mp3">
 //! </audio>
 
+#[rustc::nightly]
 #[doc(include = "../docs/rbr_2017/jess-saxeter.md")]
 pub struct Transcript;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,16 +14,20 @@
     html_favicon_url = "https://newrustacean.com/favicon.ico",
     html_root_url = "https://newrustacean.com/"
 )]
-// Enable access to the benchmarking functionality. Note that with this present,
-// we require using nightly Rust (as of 1.5).
-#![feature(test)]
-// Enable `#[doc(include = "<path>")]
-#![feature(external_doc)]
-// *Many* items are unused, because they exist only to be demo'd.
+
 #![allow(dead_code)]
 
+// Enable `#[doc(include = "<path>")]
+#[rustc::nightly]
+#[feature(external_doc)]
+// *Many* items are unused, because they exist only to be demo'd.
+
+// Enable access to the benchmarking functionality. Note that with this present,
+// we require using nightly Rust (as of 1.5).
+#[feature(test)]
 // This statement gives us access to the `test` crate for benchmarking.
 extern crate test;
+
 
 // Make the show notes public.
 pub mod e000;

--- a/src/news/rust_1_21_1_22.rs
+++ b/src/news/rust_1_21_1_22.rs
@@ -169,5 +169,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-21-1-22.md")]
 pub struct Script;

--- a/src/news/rust_1_23.rs
+++ b/src/news/rust_1_23.rs
@@ -183,5 +183,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-23.md")]
 pub struct Script;

--- a/src/news/rust_1_24.rs
+++ b/src/news/rust_1_24.rs
@@ -154,5 +154,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-24.md")]
 pub struct Script;

--- a/src/news/rust_1_25.rs
+++ b/src/news/rust_1_25.rs
@@ -192,5 +192,6 @@ pub fn demo_match(s: &str) {
     };
 }
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-25.md")]
 pub struct Script;

--- a/src/news/rust_1_26.rs
+++ b/src/news/rust_1_26.rs
@@ -184,5 +184,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-26.md")]
 pub struct Script;

--- a/src/news/rust_1_27.rs
+++ b/src/news/rust_1_27.rs
@@ -187,5 +187,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-27.md")]
 pub struct Script;

--- a/src/news/rust_1_28.rs
+++ b/src/news/rust_1_28.rs
@@ -196,5 +196,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-28.md")]
 pub struct Script;

--- a/src/news/rust_1_29_1_30.rs
+++ b/src/news/rust_1_29_1_30.rs
@@ -214,5 +214,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust_1_29_1_30.md")]
 pub struct Script;

--- a/src/news/rust_1_31/part_1.rs
+++ b/src/news/rust_1_31/part_1.rs
@@ -229,5 +229,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-31/part-1.md")]
 pub struct Script;

--- a/src/news/rust_1_31/part_2.rs
+++ b/src/news/rust_1_31/part_2.rs
@@ -233,5 +233,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-31/part-2.md")]
 pub struct Script;

--- a/src/news/rust_1_32.rs
+++ b/src/news/rust_1_32.rs
@@ -240,5 +240,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/rust-1-32.md")]
 pub struct Script;

--- a/src/news/rust_1_33_1_34.rs
+++ b/src/news/rust_1_33_1_34.rs
@@ -261,5 +261,6 @@
 //!     + GitHub: [chriskrycho](https://github.com/chriskrycho)
 //!     + Twitter: [@chriskrycho](https://www.twitter.com/chriskrycho)
 
+#[rustc::nightly]
 #[doc(include = "../docs/news/Rust 1.33 and 1.34.md")]
 pub struct Script;


### PR DESCRIPTION
1. Allow building on stable
1. Enable CI on stable, too
1. Silence some warnings on stable, too

Except the docs generation and benchmarks, the code samples can be built on stable rust, so we enable them since nightly is not the place where we'd want beginners ending up by default. Also, if nightly is used with teaching material, then new rustaceans start by ignoring stable by default, making future stabilization of feature even less likely in the future.