### PR TITLE
Set `RUSTUP_HOME` in Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,9 @@ services:
     name: newrustacean.com
     runtime: static
     buildCommand: 'make all'
+    envVars:
+    - key: RUSTUP_HOME
+      value: '/tmp'
     pullRequestPreviewsEnabled: true
     staticPublishPath: 'target/doc'
     domain: newrustacean.com


### PR DESCRIPTION
Per support:

> We mount some read-only directories to make languages available to your service and you won't be able to overwrite those. You should be able to install the nightly build in a different location by setting the `RUSTUP_HOME` environment variable to a different directory, like `/tmp`. Could you give that a try?